### PR TITLE
Masylum updated tests to libp2p swarm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libp2p-kad-routing",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Node.js Implementation of the Kademlia router for libp2p",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "protocol-buffers-stream": "^1.2.0"
   },
   "devDependencies": {
-    "abstract-peer-routing": "^0.1.0",
+    "abstract-peer-routing": "^0.1.1",
     "code": "^1.5.0",
     "lab": "^5.14.0",
     "libp2p-spdy": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "peer-info": "^0.3.0",
     "pre-commit": "^1.1.1",
     "standard": "^4.5.4",
-    "tape": "^4.2.0"
+    "tape": "^4.2.0",
+    "libp2p-swarm": "^0.5.0"
   }
 }

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -5,89 +5,96 @@ var Id = require('peer-id')
 var Peer = require('peer-info')
 var Swarm = require('libp2p-swarm')
 var tcp = require('libp2p-tcp')
+var Spdy = require('libp2p-spdy')
 
 var KadRouter = require('./../src')
 
-var swarmZero
-var swarmOne
-var swarmTwo
-var swarmThree
-var swarmFour
-var swarmFive
-
-var peerZero
-var peerOne
-var peerTwo
-var peerThree
-var peerFour
-var peerFive
-
-var krZero
-var krOne
-var krTwo
-var krThree
-var krFour
-var krFive
-
-var mh
+var sw1
+var sw2
+var sw3
+var sw4
+var sw5
+var sw6
 
 var common = {
   setup: function (t, cb) {
-    mh = multiaddr('/ip4/127.0.0.1/tcp/8090')
-    peerZero = new Peer(Id.create(), [mh])
-    swarmZero = new Swarm(peerZero)
-    swarmZero.addTransport('tcp', tcp, {}, {}, {port: 8090})
-    krZero = new KadRouter(peerZero, swarmZero)
+    var mh1 = multiaddr('/ip4/127.0.0.1/tcp/8091')
+    var p1 = new Peer(Id.create(), [])
+    sw1 = new Swarm(p1)
+    sw1.addTransport('tcp', tcp, { multiaddr: mh1 }, {}, {port: 8091}, ready)
 
-    mh = multiaddr('/ip4/127.0.0.1/tcp/8091')
-    peerOne = new Peer(Id.create(), [mh])
-    swarmOne = new Swarm(peerOne)
-    swarmOne.addTransport('tcp', tcp, {}, {}, {port: 8091})
-    krOne = new KadRouter(peerOne, swarmOne)
+    var mh2 = multiaddr('/ip4/127.0.0.1/tcp/8092')
+    var p2 = new Peer(Id.create(), [])
+    sw2 = new Swarm(p2)
+    sw2.addTransport('tcp', tcp, { multiaddr: mh2 }, {}, {port: 8092}, ready)
 
-    mh = multiaddr('/ip4/127.0.0.1/tcp/8092')
-    peerTwo = new Peer(Id.create(), [mh])
-    swarmTwo = new Swarm(peerTwo)
-    swarmTwo.addTransport('tcp', tcp, {}, {}, {port: 8092})
-    krTwo = new KadRouter(peerTwo, swarmTwo)
+    var mh3 = multiaddr('/ip4/127.0.0.1/tcp/8093')
+    var p3 = new Peer(Id.create(), [])
+    sw3 = new Swarm(p3)
+    sw3.addTransport('tcp', tcp, { multiaddr: mh3 }, {}, {port: 8093}, ready)
 
-    mh = multiaddr('/ip4/127.0.0.1/tcp/8093')
-    peerThree = new Peer(Id.create(), [mh])
-    swarmThree = new Swarm(peerThree)
-    swarmThree.addTransport('tcp', tcp, {}, {}, {port: 8093})
-    krThree = new KadRouter(peerThree, swarmThree)
+    var mh4 = multiaddr('/ip4/127.0.0.1/tcp/8094')
+    var p4 = new Peer(Id.create(), [])
+    sw4 = new Swarm(p4)
+    sw4.addTransport('tcp', tcp, { multiaddr: mh4 }, {}, {port: 8094}, ready)
 
-    mh = multiaddr('/ip4/127.0.0.1/tcp/8094')
-    peerFour = new Peer(Id.create(), [mh])
-    swarmFour = new Swarm(peerFour)
-    swarmFour.addTransport('tcp', tcp, {}, {}, {port: 8094})
-    krFour = new KadRouter(peerFour, swarmFour)
+    var mh5 = multiaddr('/ip4/127.0.0.1/tcp/8095')
+    var p5 = new Peer(Id.create(), [])
+    sw5 = new Swarm(p5)
+    sw5.addTransport('tcp', tcp, { multiaddr: mh5 }, {}, {port: 8095}, ready)
 
-    mh = multiaddr('/ip4/127.0.0.1/tcp/8095')
-    peerFive = new Peer(Id.create(), [mh])
-    swarmFive = new Swarm(peerFive)
-    swarmFive.addTransport('tcp', tcp, {}, {}, {port: 8095})
-    krFive = new KadRouter(peerFive, swarmFive)
+    var mh6 = multiaddr('/ip4/127.0.0.1/tcp/8096')
+    var p6 = new Peer(Id.create(), [])
+    sw6 = new Swarm(p6)
+    sw6.addTransport('tcp', tcp, { multiaddr: mh6 }, {}, {port: 8096}, ready)
 
-    krZero.addPeer(peerOne)
-    krZero.addPeer(peerTwo)
-    krZero.addPeer(peerThree)
-    krOne.addPeer(peerFour)
-    krOne.addPeer(peerFive)
-    krTwo.addPeer(peerZero)
-    krThree.addPeer(peerZero)
-    krFour.addPeer(peerZero)
-    krFive.addPeer(peerZero)
+    var counter = 0
 
-    cb(null, krZero)
+    function ready () {
+      counter++
+      if (counter < 6) {
+        return
+      }
+      sw1.addStreamMuxer('spdy', Spdy, {})
+      sw1.enableIdentify()
+      sw2.addStreamMuxer('spdy', Spdy, {})
+      sw2.enableIdentify()
+      sw3.addStreamMuxer('spdy', Spdy, {})
+      sw3.enableIdentify()
+      sw4.addStreamMuxer('spdy', Spdy, {})
+      sw4.enableIdentify()
+      sw5.addStreamMuxer('spdy', Spdy, {})
+      sw5.enableIdentify()
+      sw6.addStreamMuxer('spdy', Spdy, {})
+      sw6.enableIdentify()
+
+      var krOne = new KadRouter(p1, sw1)
+      var krTwo = new KadRouter(p2, sw2)
+      var krThree = new KadRouter(p3, sw3)
+      var krFour = new KadRouter(p4, sw4)
+      var krFive = new KadRouter(p5, sw5)
+      var krSix = new KadRouter(p6, sw6)
+
+      krOne.addPeer(p2)
+      krOne.addPeer(p3)
+      krOne.addPeer(p4)
+      krTwo.addPeer(p5)
+      krTwo.addPeer(p6)
+      krThree.addPeer(p1)
+      krFour.addPeer(p1)
+      krFive.addPeer(p1)
+      krSix.addPeer(p1)
+
+      cb(null, krOne)
+    }
   },
   teardown: function () {
-    swarmZero.closeListener('tcp')
-    swarmOne.closeListener('tcp')
-    swarmTwo.closeListener('tcp')
-    swarmThree.closeListener('tcp')
-    swarmFour.closeListener('tcp')
-    swarmFive.closeListener('tcp')
+    sw1.close()
+    sw2.close()
+    sw3.close()
+    sw4.close()
+    sw5.close()
+    sw6.close()
   }
 }
 

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -3,7 +3,8 @@ var tests = require('abstract-peer-routing/tests')
 var multiaddr = require('multiaddr')
 var Id = require('peer-id')
 var Peer = require('peer-info')
-var Swarm = require('ipfs-swarm')
+var Swarm = require('libp2p-swarm')
+var tcp = require('libp2p-tcp')
 
 var KadRouter = require('./../src')
 
@@ -28,36 +29,44 @@ var krThree
 var krFour
 var krFive
 
+var mh
+
 var common = {
   setup: function (t, cb) {
-    peerZero = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8090')])
-    swarmZero = new Swarm()
-    swarmZero.listen(8090)
+    mh = multiaddr('/ip4/127.0.0.1/tcp/8090')
+    peerZero = new Peer(Id.create(), [mh])
+    swarmZero = new Swarm(peerZero)
+    swarmZero.addTransport('tcp', tcp, {}, {}, {port: 8090})
     krZero = new KadRouter(peerZero, swarmZero)
 
-    peerOne = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8091')])
-    swarmOne = new Swarm()
-    swarmOne.listen(8091)
+    mh = multiaddr('/ip4/127.0.0.1/tcp/8091')
+    peerOne = new Peer(Id.create(), [mh])
+    swarmOne = new Swarm(peerOne)
+    swarmOne.addTransport('tcp', tcp, {}, {}, {port: 8091})
     krOne = new KadRouter(peerOne, swarmOne)
 
-    peerTwo = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8092')])
-    swarmTwo = new Swarm()
-    swarmTwo.listen(8092)
+    mh = multiaddr('/ip4/127.0.0.1/tcp/8092')
+    peerTwo = new Peer(Id.create(), [mh])
+    swarmTwo = new Swarm(peerTwo)
+    swarmTwo.addTransport('tcp', tcp, {}, {}, {port: 8092})
     krTwo = new KadRouter(peerTwo, swarmTwo)
 
-    peerThree = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8093')])
-    swarmThree = new Swarm()
-    swarmThree.listen(8093)
+    mh = multiaddr('/ip4/127.0.0.1/tcp/8093')
+    peerThree = new Peer(Id.create(), [mh])
+    swarmThree = new Swarm(peerThree)
+    swarmThree.addTransport('tcp', tcp, {}, {}, {port: 8093})
     krThree = new KadRouter(peerThree, swarmThree)
 
-    peerFour = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8094')])
-    swarmFour = new Swarm()
-    swarmFour.listen(8094)
+    mh = multiaddr('/ip4/127.0.0.1/tcp/8094')
+    peerFour = new Peer(Id.create(), [mh])
+    swarmFour = new Swarm(peerFour)
+    swarmFour.addTransport('tcp', tcp, {}, {}, {port: 8094})
     krFour = new KadRouter(peerFour, swarmFour)
 
-    peerFive = new Peer(Id.create(), [multiaddr('/ip4/127.0.0.1/tcp/8095')])
-    swarmFive = new Swarm()
-    swarmFive.listen(8095)
+    mh = multiaddr('/ip4/127.0.0.1/tcp/8095')
+    peerFive = new Peer(Id.create(), [mh])
+    swarmFive = new Swarm(peerFive)
+    swarmFive.addTransport('tcp', tcp, {}, {}, {port: 8095})
     krFive = new KadRouter(peerFive, swarmFive)
 
     krZero.addPeer(peerOne)
@@ -72,15 +81,13 @@ var common = {
 
     cb(null, krZero)
   },
-  teardown: function (t, cb) {
-    swarmZero.closeListener()
-    swarmOne.closeListener()
-    swarmTwo.closeListener()
-    swarmThree.closeListener()
-    swarmFour.closeListener()
-    swarmFive.closeListener()
-
-    // cb()
+  teardown: function () {
+    swarmZero.closeListener('tcp')
+    swarmOne.closeListener('tcp')
+    swarmTwo.closeListener('tcp')
+    swarmThree.closeListener('tcp')
+    swarmFour.closeListener('tcp')
+    swarmFive.closeListener('tcp')
   }
 }
 

--- a/tests/compliance.js
+++ b/tests/compliance.js
@@ -89,12 +89,12 @@ var common = {
     }
   },
   teardown: function () {
-    sw1.close()
-    sw2.close()
-    sw3.close()
-    sw4.close()
-    sw5.close()
-    sw6.close()
+    sw1.closeListener('tcp', function () {})
+    sw2.closeListener('tcp', function () {})
+    sw3.closeListener('tcp', function () {})
+    sw4.closeListener('tcp', function () {})
+    sw5.closeListener('tcp', function () {})
+    sw6.closeListener('tcp', function () {})
   }
 }
 


### PR DESCRIPTION
Following https://github.com/diasdavid/node-libp2p-kad-routing/pull/4

Sorry if it came out of the blue, I had started a issue on libp2p-swarm to discuss the revisit and added to my sprint this week. Ref: https://github.com/diasdavid/node-libp2p-swarm/issues/8

I was unable to run the compliance tests with your PR, so I updated it and added Spdy and Identify to the mix.

```
// for the record
» npm run compliance                                                                                      

> libp2p-kad-routing@0.1.6 compliance /Users/david/Documents/code/ipfs/libp2p/node/peer-routing/libp2p-kad-routing
> node tests/compliance.js

TAP version 13
# Simple findPeers test
ok 1 null
/Users/david/Documents/code/ipfs/libp2p/node/peer-routing/libp2p-kad-routing/node_modules/libp2p-swarm/src/swarm.js:66
      callback()
      ^

TypeError: callback is not a function
    at Server.ready (/Users/david/Documents/code/ipfs/libp2p/node/peer-routing/libp2p-kad-routing/node_modules/libp2p-swarm/src/swarm.js:66:7)
...
```

Now tests pass:

```
» npm run compliance                                                                                      

> libp2p-kad-routing@0.1.6 compliance /Users/david/Documents/code/ipfs/libp2p/node/peer-routing/libp2p-kad-routing
> node tests/compliance.js

TAP version 13
# Simple findPeers test
ok 1 null
ok 2 null
ok 3 should be equal
# time: 145 ms
```

But still has the same bug described on https://github.com/diasdavid/node-libp2p-kad-routing/issues/2.

What happens is that because it gets crazy hard to close gracefully all the streams opened with all the wrapping involved by doing multistream handshakes and upgrades to stream muxer, it is easy to miss some of the parts to close so that the whole thing can end.

Thank you for helping looking into this :) 
